### PR TITLE
Added clarification for release badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 </h1>
 
 <div align="center">
-<a href="https://github.com/DrSolidDevil/mlr-gd//releases/latest"><img alt="GitHub Release" src="https://img.shields.io/github/v/release/drsoliddevil/mlr-gd"></a>
+<a href="https://github.com/DrSolidDevil/mlr-gd//releases/latest"><img alt="GitHub Release" src="https://img.shields.io/github/v/release/drsoliddevil/mlr-gd?label=latest%20release"></a>
 <a href="https://pypi.org/project/mlr-gd/"><img alt="PyPI - Downloads" src="https://img.shields.io/pypi/dm/mlr-gd?label=PyPi%20downloads"></a>
 <img alt="PyPI - Python Version" src="https://img.shields.io/pypi/pyversions/mlr-gd">
 <img alt="GitHub repo size" src="https://img.shields.io/github/repo-size/DrSolidDevil/mlr-gd">


### PR DESCRIPTION
Since this readme will also be on PyPi, it can confuse people when selecting a specific release and seeing a newer version for release.  
Although when uploading to PyPi, the readme is the one that was active at that moment, it still fetches the image from shields.io which will update with new releases.


**What type of pull-request is this? (check all applicable)**
- [ ] Update (new version)
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [X] Documentation Update


